### PR TITLE
Import from more reliable module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "splink_data_generation"
-version = "1.0.0"
+version = "1.0.1"
 description = "Generate synthetic data with a specified data generating process"
 authors = ["Robin Linacre <robinlinacre@hotmail.com>"]
 

--- a/splink_data_generation/generate_data_random.py
+++ b/splink_data_generation/generate_data_random.py
@@ -15,7 +15,7 @@ import numpy as np
 import pandas as pd
 from scipy.stats import norm
 
-from splink.settings import complete_settings_dict
+from splink.default_settings import complete_settings_dict
 
 
 def _gen_cov_matrix_no_correlation(settings):


### PR DESCRIPTION
In future, it will not be possible to import `complete_settings_dict` from splink.settings